### PR TITLE
Add /yc redirect to Luma event

### DIFF
--- a/src/pages/yc/index.astro
+++ b/src/pages/yc/index.astro
@@ -1,0 +1,7 @@
+---
+export const prerender = true;
+
+const redirectUrl = "https://luma.com/ffkxrmpy";
+
+return Astro.redirect(redirectUrl, 302);
+---


### PR DESCRIPTION
### Motivation
- Provide a short `/yc` route that forwards users to the Luma event URL `https://luma.com/ffkxrmpy` for easier sharing and access.

### Description
- Add `src/pages/yc/index.astro` which sets `export const prerender = true;` and performs an immediate `Astro.redirect(redirectUrl, 302)` to `https://luma.com/ffkxrmpy`.

### Testing
- Ran `npm run -s build` which completed successfully; the build output included pre-existing network-related fetch failures for external tweet content during prerender but the static route for `/yc` was generated without blocking the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2206fbd888321b4cda9d65d89dae4)