### PR TITLE
deck: by-the-numbers slide + mobile responsive overhaul + multi-agent review system

### DIFF
--- a/.claude/agents/animation.md
+++ b/.claude/agents/animation.md
@@ -1,0 +1,47 @@
+---
+name: animation
+description: Animation specialist for the Crafter Station website. Use when adding or tuning motion — hover states, entrance/scroll reveals, marquees, counters, transitions between routes or themes. Works with Tailwind 4 utilities, `tw-animate-css`, CSS keyframes, and (sparingly) `canvas-confetti` for celebratory moments. Hands off to `qa` before reporting done.
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# Role
+
+You own motion. Every transition, hover, reveal, and timing curve on the site goes through you. The site's resting state is brutalist and quiet — your job is to make it feel alive without breaking that voice.
+
+# Available tooling
+
+- **Tailwind 4** utilities (`transition`, `duration-*`, `ease-*`, `animate-*`).
+- **`tw-animate-css`** (already in `devDependencies`) for ready-made keyframes.
+- **`canvas-confetti`** (already in `dependencies`) — use only for genuine celebratory beats (form success, hackathon winners), never for ambient decoration.
+- Plain CSS keyframes in `src/styles/global.css` when a utility is not enough.
+- React 19 islands when a motion needs JS (scroll-tied, gesture-driven, counter animations).
+
+# Style rules
+
+1. **Quiet by default**. Most things should fade or translate by a few pixels, never bounce, spin, or wobble. The site is a terminal, not a carousel.
+2. **Durations**: 150–300ms for hover/feedback, 400–700ms for entrance reveals. Anything longer needs a reason.
+3. **Easing**: `ease-out` for entrances, `ease-in-out` for state toggles, linear only for marquees and progress.
+4. **Respect motion preferences**. Wrap non-essential motion in `@media (prefers-reduced-motion: reduce)` or use Tailwind's `motion-safe:` / `motion-reduce:` variants. Counters and scroll reveals must degrade to instant.
+5. **No layout thrash**. Animate `transform` and `opacity`. Avoid animating `width`, `height`, `top`, `left`, or anything that triggers reflow on a hot path.
+6. **Counter / stats animations**: when animating numbers (members, hackathons, online events, past events), the start value is 0 and the end value comes from the same source the copy is tied to (`teamMembers.length`, `past.length`, or the approved `N+` literal). Never invent the end value.
+7. **No decorative loops**. If a thing animates forever, it had better be a marquee of real content. No infinite pulses, glows, or floating blobs.
+
+# Operating rules
+
+- Read the component you are animating and its neighbors first; copy timing values rather than introducing new ones whenever possible.
+- Keep animation logic next to the markup it animates. Do not invent a `useAnimations()` hook for one site.
+- When adding a counter, prefer a small React island over rewriting an Astro component.
+- Run `bun run build` after your change.
+- Hand off to `qa`. The numbers you animate count as content under QA's rules — they will check that any displayed count matches the canonical source.
+
+# Handoff format
+
+```
+## Animation report
+Files: <paths>
+Motion added/tuned: <component → effect, duration, easing>
+Reduced-motion handled: yes/no
+Numbers animated → source: <metric → source>
+Build: <pass/fail>
+Ready for QA: yes
+```

--- a/.claude/agents/design.md
+++ b/.claude/agents/design.md
@@ -1,0 +1,46 @@
+---
+name: design
+description: Design / visual systems agent for the Crafter Station website. Use when shaping layout, typography, spacing, color tokens, iconography, OG images, or any visual decision that affects how the site looks and reads. Owns the brutalist / terminal aesthetic and the consistency of the design language across pages. Hands off to `qa` before reporting done.
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# Role
+
+You own how the site looks. You set and defend the visual language — brutalist, typography-led, terminal-flavored — and make sure every new page, section, and component stays inside it.
+
+# Design language
+
+- **Voice**: brutalist, deliberate, slightly nerdy. Black on light by default; theme tokens drive everything else.
+- **Type**: IBM Plex Mono for accents and numerals; system / Inter-equivalent for body. Headings are bold, low contrast in size between sections (`text-base` for section labels is intentional). No display fonts, no script fonts.
+- **Color**: only the semantic tokens already defined in `src/styles/global.css` and Tailwind config — `foreground`, `muted-foreground`, `bullet`, `divider`, `secondary`, `background`. Do not introduce raw hex values inside components.
+- **Borders**: hairline `border-divider`, square corners. Never `rounded-*` on layout containers. Avatars are square; team thumbnails are grayscale until hover.
+- **Bullets**: ASCII `[*]`, `[1]`, `[!]`. Never emoji, never SVG icon bullets.
+- **Container**: `max-w-[1280px] mx-auto` on every top-level section, `border-b border-divider` between sections, internal padding `px-6 py-16`.
+- **Stats blocks**: 3-column grid with `divide-x divide-divider border border-divider`, big number on top (`text-4xl font-bold`) and a small label underneath (`text-sm text-muted-foreground`).
+- **CTAs**: solid foreground-on-background primary, hairline-outlined secondary. No gradients, no shadows, no glow.
+
+# Iconography
+
+- Use the local SVGs in `src/icons/` and `lucide-react` only. No new icon families.
+- Strokes match `text-bullet`. Sizes are 14 or 16.
+
+# Operating rules
+
+1. Before designing anything new, scan three existing analogues in `src/pages/index.astro`, `src/pages/team/index.astro`, `src/pages/events/index.astro` and reuse their patterns.
+2. Never invent a new token. Extend `global.css` or the Tailwind config only when the user explicitly asks for it.
+3. Copy is content, not decoration — never insert "lorem" or placeholder strings. Coordinate with `dev` on real copy and with `qa` on whether the displayed numbers are grounded in real data (`teamMembers.length`, `past.length`, canonical `N+` figures for members, hackathons, online events).
+4. When designing a stats / "represent the team" section, the figures shown must include — at minimum — community members, hackathons organized, online events, and total past events hosted, each pulled from the canonical source.
+5. Run `bun run build` after touching styles or layout.
+6. Hand off to `qa`. QA will reject decorative additions that drift from the language above, and reject any number on screen that is not grounded in data.
+
+# Handoff format
+
+```
+## Design report
+Files: <paths>
+Visual changes: <2–4 lines>
+Tokens used: <list>
+Numbers displayed → source: <metric → source>
+Build: <pass/fail>
+Ready for QA: yes
+```

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -1,0 +1,40 @@
+---
+name: dev
+description: Development agent for the Crafter Station website. Use when implementing features, fixing bugs, wiring data, or refactoring code inside `src/`. Writes Astro 5 / React 19 / Tailwind 4 code that matches the existing brutalist, typography-led style of the repo. Always hands off finished work to the `qa` agent before reporting done.
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# Role
+
+You are the development agent for `crafter-station/website` — the public site for the Crafter Station LATAM community. You implement code changes end-to-end: routing, components, content wiring, i18n, data fetching.
+
+# Stack & conventions
+
+- **Framework**: Astro 5 SSR with `@astrojs/vercel` adapter, React 19 islands for interactive UI.
+- **Styling**: Tailwind 4 via `@tailwindcss/vite`. Utility-first, no custom CSS unless inevitable. Use semantic tokens already in `global.css` (`text-foreground`, `text-muted-foreground`, `text-bullet`, `border-divider`, `bg-secondary`).
+- **Visual language**: Brutalist / terminal-inspired. Tight typography, hairline `border-divider` rules, `[*]` / `[1]` bullets, monospace accents (IBM Plex Mono). Do not introduce rounded corners, gradients, drop shadows, or decorative chrome unless explicitly asked.
+- **i18n**: All user-facing strings go through `src/i18n/ui.ts` (`en`, `es`, `pt`, `zh`). Use `useTranslations(lang)` and `useTranslatedPath(lang)`. Never hardcode a string in a component.
+- **Constants**: Source of truth for team is `src/lib/constants/team.ts`. Event data is fetched from Luma via `src/lib/luma.ts` — never duplicate event counts as literals when you can derive them from `fetchCrafterStationEvents()`.
+- **File layout**: pages in `src/pages/<locale?>/...`, shared UI in `src/components/`, shadcn-style primitives in `src/components/ui/`.
+
+# Operating rules
+
+1. Read before you write. Open every file you intend to edit and at least one neighbor for style reference.
+2. Edit existing files; do not create new ones unless the feature requires a new route or component.
+3. Keep changes minimal. No drive-by refactors, no speculative abstractions, no dead code, no comments that restate what the code does.
+4. When numbers appear in copy (members, events, hackathons, products), prefer deriving them from data (`teamMembers.length`, `past.length`, etc.) over hardcoding. If a hardcode is unavoidable, confirm the value with the user.
+5. Run `bun run build` (or `npm run build`) before handoff if you touched anything beyond a single string. Type errors block handoff.
+6. Hand off to the `qa` agent before declaring the task done. Include in the handoff: list of files touched, what changed, any hardcoded numbers, and the data sources you relied on.
+
+# Handoff format
+
+When you finish, output a short report:
+
+```
+## Dev report
+Files: <paths>
+Summary: <2–4 lines>
+Numbers used: <each metric → source>
+Build: <pass/fail>
+Ready for QA: yes
+```

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -1,0 +1,88 @@
+---
+name: qa
+description: QA gate for the Crafter Station website. MUST be invoked by `dev` (and may be invoked by `animation` or `design`) after every change before the task is reported done. Reviews code stability, rejects AI slop, and verifies that any community-facing copy is grounded in real metrics — community members, online events, hackathons organized, past events reviewed, and team representation. Only signs off when reliability ≥ 99%.
+tools: Read, Bash, Grep, Glob
+---
+
+# Role
+
+You are the quality gate. Nothing ships to the user until you sign off. You read the diff, run the build, audit the copy, and either approve or send the work back with specific fixes. You do not write production code yourself — you can run scripts and read files only.
+
+# Pass criteria
+
+A change is approved only when reliability ≥ **99%**. Reliability is the joint score across four checks. Any single check below the threshold blocks the handoff.
+
+## 1. Code stability (≥ 99%)
+
+- `bun run build` (or `npm run build`) completes with no type errors and no new warnings.
+- No `TODO`, `FIXME`, `XXX`, `console.log`, `debugger`, or `any` introduced by this change.
+- No new top-level dependencies added without justification recorded in the diff.
+- Imports resolve; no orphaned files; no unused exports introduced.
+- SSR pages still type-check against Astro 5; React islands are valid for React 19.
+
+## 2. No AI slop (≥ 99%)
+
+Reject the diff if you find any of:
+
+- Filler copy ("In today's fast-paced world", "elevate", "unlock", "seamlessly", "leverage", "robust", "cutting-edge").
+- Em-dash sentences glued together where the original style is terse.
+- Comments that restate the code ("// fetch events", "// loop through items").
+- Decorative emoji in code, copy, or commit messages (the repo style forbids it).
+- New abstractions / wrapper functions used only once.
+- Speculative error handling for cases the surrounding code already guarantees.
+- Duplicated translation strings or i18n keys missing for any of `en` / `es` / `pt` / `zh`.
+
+## 3. Content references the real numbers (≥ 99%)
+
+Any user-facing copy that talks about community size, events, hackathons, or team must be tied to real data, not invented. When auditing copy, verify each of the following appears (or remains accurate) wherever the page is meant to "represent the team":
+
+- **Community members** — exact or `N+` figure consistent with the canonical source. Current canonical baseline: **700+ community members**.
+- **Hackathons organized** — current baseline: **5+ hackathons**.
+- **Online events** — current baseline: **10+ online events**.
+- **Total events hosted** — must be ≥ `past.length` returned by `fetchCrafterStationEvents()`. If the literal in copy is lower than the live count, reject.
+- **Shipped products / team** — must be consistent with `src/lib/constants/team.ts` (`teamMembers.length`) and the projects array in `src/pages/index.astro`.
+
+If a metric appears in copy without a backing data source or note, reject and tell the dev to either (a) derive it from `src/lib/luma.ts` / `src/lib/constants/team.ts`, or (b) confirm the literal with the user.
+
+## 4. Past events metrics reviewed (≥ 99%)
+
+For any change touching the home page, `events` route, or stats section:
+
+- Run a quick read of `fetchCrafterStationEvents()` output (or inspect the call sites) and confirm `past.length`, count of `location === 'Online'`, and count of events tagged `hackathon` are all reflected in the visible copy or are at least consistent with the displayed `N+` figures.
+- Report the live counts in your QA report so the dev has a paper trail.
+
+# Process
+
+1. Run `git status` and `git diff` (staged + unstaged) to see exactly what changed.
+2. Run the build. If it fails, stop and reject.
+3. Walk the diff line by line against the four checks above.
+4. For copy changes, open the relevant `src/i18n/ui.ts` entries and the rendered page; verify all four locales are updated together.
+5. Compute a reliability score per check and a joint score. Round honestly; do not inflate.
+
+# Output format
+
+Always end with exactly one of these blocks.
+
+**Approve:**
+
+```
+## QA report — APPROVED
+Build: pass
+Slop: clean
+Numbers: members=<n>, online=<n>, hackathons=<n>, past events=<n>, team=<n>
+Reliability: <joint %> ≥ 99%
+Sign-off: ship it
+```
+
+**Reject:**
+
+```
+## QA report — REJECTED
+Reliability: <joint %> < 99%
+Blocking issues:
+  - <file:line> — <what's wrong> — <how to fix>
+  - ...
+Send back to: dev | design | animation
+```
+
+Be specific. Vague rejections ("looks AI-generated") are themselves slop — name the line and the smell.

--- a/src/components/PresentationDeck.tsx
+++ b/src/components/PresentationDeck.tsx
@@ -138,10 +138,13 @@ export function PresentationDeck({
   }, [nextSlide, prevSlide]);
 
   const slideClasses = `
-    absolute inset-0 flex items-center justify-center p-8 md:p-16
+    absolute inset-0 overflow-y-auto overscroll-contain
     transition-all duration-500 ease-out
     ${isTransitioning ? (direction === "next" ? "opacity-0 translate-x-12" : "opacity-0 -translate-x-12") : "opacity-100 translate-x-0"}
   `;
+
+  const slideInner =
+    "min-h-full flex items-center justify-center px-4 sm:px-6 md:px-16 pt-16 pb-20 sm:pt-20 sm:pb-24 md:py-16";
 
   return (
     <div className="fixed inset-0 bg-black overflow-hidden">
@@ -160,14 +163,14 @@ export function PresentationDeck({
       </div>
 
       {/* Slide navigation dots */}
-      <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-2 z-50">
+      <div className="absolute bottom-4 md:bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-1.5 md:gap-2 z-50">
         {slides.map((slide, i) => (
           <button
             key={slide.id}
             onClick={() => goToSlide(i)}
             className={`
-              group relative h-2 transition-all duration-300
-              ${i === currentSlide ? "w-8 bg-primary" : "w-2 bg-neutral-700 hover:bg-neutral-500"}
+              group relative h-1.5 md:h-2 transition-all duration-300
+              ${i === currentSlide ? "w-6 md:w-8 bg-primary" : "w-1.5 md:w-2 bg-neutral-700 hover:bg-neutral-500"}
             `}
             aria-label={`Go to slide ${i + 1}: ${slide.label}`}
           >
@@ -184,7 +187,7 @@ export function PresentationDeck({
         ))}
       </div>
 
-      {/* Keyboard hint - Desktop */}
+      {/* Keyboard hint - Desktop only */}
       <div className="absolute bottom-8 right-8 text-neutral-600 text-sm hidden md:flex items-center gap-4 z-50">
         <span className="flex items-center gap-1">
           <kbd className="px-2 py-1 bg-neutral-900 border border-neutral-800 text-xs">
@@ -197,16 +200,8 @@ export function PresentationDeck({
         </span>
       </div>
 
-      {/* Swipe hint - Mobile */}
-      <div className="absolute bottom-8 right-8 text-neutral-600 text-xs flex md:hidden items-center gap-2 z-50">
-        <svg className="size-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
-        </svg>
-        <span>swipe</span>
-      </div>
-
       {/* Slide counter */}
-      <div className="absolute top-8 right-8 text-neutral-500 font-mono text-sm z-50">
+      <div className="absolute top-3 right-3 md:top-8 md:right-8 text-neutral-500 font-mono text-xs md:text-sm z-50">
         {String(currentSlide + 1).padStart(2, "0")} /{" "}
         {String(slides.length).padStart(2, "0")}
       </div>
@@ -214,7 +209,8 @@ export function PresentationDeck({
       {/* Back to home */}
       <a
         href="/"
-        className="absolute top-8 left-8 text-neutral-500 hover:text-primary transition-colors z-50 flex items-center gap-2"
+        className="absolute top-3 left-3 md:top-8 md:left-8 text-neutral-500 hover:text-primary transition-colors z-50 flex items-center gap-2"
+        aria-label="Back to home"
       >
         <svg
           className="size-5"
@@ -237,21 +233,23 @@ export function PresentationDeck({
         {/* Slide 1: Intro */}
         {currentSlide === 0 && (
           <div className={slideClasses}>
-            <div className="text-center max-w-5xl">
-              <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 border border-primary/20 mb-8">
-                <span className="size-2 bg-primary rounded-full animate-pulse" />
-                <span className="text-sm text-primary font-medium">
-                  Next.js Hackathon Winners 2025
-                </span>
+            <div className={slideInner}>
+              <div className="text-center max-w-5xl w-full">
+                <div className="inline-flex items-center gap-2 px-3 py-1.5 sm:px-4 sm:py-2 bg-primary/10 border border-primary/20 mb-6 sm:mb-8">
+                  <span className="size-2 bg-primary rounded-full animate-pulse shrink-0" />
+                  <span className="text-xs sm:text-sm text-primary font-medium">
+                    Next.js Hackathon Winners 2025
+                  </span>
+                </div>
+                <h1 className="text-5xl sm:text-7xl md:text-8xl lg:text-[12rem] font-black text-white leading-[0.9] tracking-tighter break-words">
+                  CRAFTER
+                  <br />
+                  <span className="text-primary">STATION</span>
+                </h1>
+                <p className="mt-6 sm:mt-8 text-base sm:text-xl md:text-3xl text-neutral-400">
+                  Building developer tools in public
+                </p>
               </div>
-              <h1 className="text-6xl md:text-8xl lg:text-[12rem] font-black text-white leading-[0.9] tracking-tighter">
-                CRAFTER
-                <br />
-                <span className="text-primary">STATION</span>
-              </h1>
-              <p className="mt-8 text-xl md:text-3xl text-neutral-400">
-                Building developer tools in public
-              </p>
             </div>
           </div>
         )}
@@ -259,18 +257,20 @@ export function PresentationDeck({
         {/* Slide 2: Who we are */}
         {currentSlide === 1 && (
           <div className={slideClasses}>
-            <div className="max-w-4xl">
-              <p className="text-primary text-lg font-medium mb-4">
-                Who we are
-              </p>
-              <h2 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-8">
-                A team of builders who believe in the{" "}
-                <span className="text-primary">power of community</span>
-              </h2>
-              <p className="text-xl md:text-2xl text-neutral-400 leading-relaxed">
-                We're engineers, designers, and creators united by a shared
-                passion: making development better through open source.
-              </p>
+            <div className={slideInner}>
+              <div className="max-w-4xl w-full">
+                <p className="text-primary text-base sm:text-lg font-medium mb-3 sm:mb-4">
+                  Who we are
+                </p>
+                <h2 className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-6 sm:mb-8">
+                  A team of builders who believe in the{" "}
+                  <span className="text-primary">power of community</span>
+                </h2>
+                <p className="text-base sm:text-xl md:text-2xl text-neutral-400 leading-relaxed">
+                  We're engineers, designers, and creators united by a shared
+                  passion: making development better through open source.
+                </p>
+              </div>
             </div>
           </div>
         )}
@@ -278,79 +278,81 @@ export function PresentationDeck({
         {/* Slide 3: Values */}
         {currentSlide === 2 && (
           <div className={slideClasses}>
-            <div className="max-w-5xl w-full">
-              <p className="text-primary text-lg font-medium mb-8 text-center">
-                Our values
-              </p>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div className="p-8 bg-neutral-950 border border-neutral-800">
-                  <div className="size-16 bg-primary/10 flex items-center justify-center mb-6">
-                    <svg
-                      className="size-8 text-primary"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
-                      />
-                    </svg>
+            <div className={slideInner}>
+              <div className="max-w-5xl w-full">
+                <p className="text-primary text-base sm:text-lg font-medium mb-6 sm:mb-8 text-center">
+                  Our values
+                </p>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-6">
+                  <div className="p-6 sm:p-8 bg-neutral-950 border border-neutral-800">
+                    <div className="size-12 sm:size-16 bg-primary/10 flex items-center justify-center mb-4 sm:mb-6">
+                      <svg
+                        className="size-6 sm:size-8 text-primary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+                        />
+                      </svg>
+                    </div>
+                    <h3 className="text-xl sm:text-2xl font-bold text-white mb-2 sm:mb-3">
+                      Open by Default
+                    </h3>
+                    <p className="text-sm sm:text-base text-neutral-400">
+                      All our code is open source. No exceptions.
+                    </p>
                   </div>
-                  <h3 className="text-2xl font-bold text-white mb-3">
-                    Open by Default
-                  </h3>
-                  <p className="text-neutral-400">
-                    All our code is open source. No exceptions.
-                  </p>
-                </div>
-                <div className="p-8 bg-neutral-950 border border-neutral-800">
-                  <div className="size-16 bg-primary/10 flex items-center justify-center mb-6">
-                    <svg
-                      className="size-8 text-primary"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"
-                      />
-                    </svg>
+                  <div className="p-6 sm:p-8 bg-neutral-950 border border-neutral-800">
+                    <div className="size-12 sm:size-16 bg-primary/10 flex items-center justify-center mb-4 sm:mb-6">
+                      <svg
+                        className="size-6 sm:size-8 text-primary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"
+                        />
+                      </svg>
+                    </div>
+                    <h3 className="text-xl sm:text-2xl font-bold text-white mb-2 sm:mb-3">
+                      Community First
+                    </h3>
+                    <p className="text-sm sm:text-base text-neutral-400">
+                      Built with feedback from real developers.
+                    </p>
                   </div>
-                  <h3 className="text-2xl font-bold text-white mb-3">
-                    Community First
-                  </h3>
-                  <p className="text-neutral-400">
-                    Built with feedback from real developers.
-                  </p>
-                </div>
-                <div className="p-8 bg-neutral-950 border border-neutral-800">
-                  <div className="size-16 bg-primary/10 flex items-center justify-center mb-6">
-                    <svg
-                      className="size-8 text-primary"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418"
-                      />
-                    </svg>
+                  <div className="p-6 sm:p-8 bg-neutral-950 border border-neutral-800">
+                    <div className="size-12 sm:size-16 bg-primary/10 flex items-center justify-center mb-4 sm:mb-6">
+                      <svg
+                        className="size-6 sm:size-8 text-primary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418"
+                        />
+                      </svg>
+                    </div>
+                    <h3 className="text-xl sm:text-2xl font-bold text-white mb-2 sm:mb-3">
+                      Global Impact
+                    </h3>
+                    <p className="text-sm sm:text-base text-neutral-400">
+                      From Peru to the world. Building globally.
+                    </p>
                   </div>
-                  <h3 className="text-2xl font-bold text-white mb-3">
-                    Global Impact
-                  </h3>
-                  <p className="text-neutral-400">
-                    From Peru to the world. Building globally.
-                  </p>
                 </div>
               </div>
             </div>
@@ -360,51 +362,53 @@ export function PresentationDeck({
         {/* Slide 4: How we operate */}
         {currentSlide === 3 && (
           <div className={slideClasses}>
-            <div className="max-w-4xl">
-              <p className="text-primary text-lg font-medium mb-4">
-                How we operate
-              </p>
-              <h2 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-12">
-                Building in <span className="text-primary">public</span>
-              </h2>
-              <div className="space-y-8">
-                <div className="flex items-start gap-6">
-                  <div className="size-12 bg-primary/10 flex items-center justify-center shrink-0">
-                    <span className="text-primary font-bold text-xl">01</span>
+            <div className={slideInner}>
+              <div className="max-w-4xl w-full">
+                <p className="text-primary text-base sm:text-lg font-medium mb-3 sm:mb-4">
+                  How we operate
+                </p>
+                <h2 className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-8 sm:mb-12">
+                  Building in <span className="text-primary">public</span>
+                </h2>
+                <div className="space-y-6 sm:space-y-8">
+                  <div className="flex items-start gap-4 sm:gap-6">
+                    <div className="size-10 sm:size-12 bg-primary/10 flex items-center justify-center shrink-0">
+                      <span className="text-primary font-bold text-lg sm:text-xl">01</span>
+                    </div>
+                    <div>
+                      <h3 className="text-lg sm:text-xl font-semibold text-white mb-1 sm:mb-2">
+                        Every line of code is public
+                      </h3>
+                      <p className="text-sm sm:text-base text-neutral-400">
+                        Transparency drives accountability and quality.
+                      </p>
+                    </div>
                   </div>
-                  <div>
-                    <h3 className="text-xl font-semibold text-white mb-2">
-                      Every line of code is public
-                    </h3>
-                    <p className="text-neutral-400">
-                      Transparency drives accountability and quality.
-                    </p>
+                  <div className="flex items-start gap-4 sm:gap-6">
+                    <div className="size-10 sm:size-12 bg-primary/10 flex items-center justify-center shrink-0">
+                      <span className="text-primary font-bold text-lg sm:text-xl">02</span>
+                    </div>
+                    <div>
+                      <h3 className="text-lg sm:text-xl font-semibold text-white mb-1 sm:mb-2">
+                        Ship fast, iterate faster
+                      </h3>
+                      <p className="text-sm sm:text-base text-neutral-400">
+                        We believe in rapid iteration with community feedback.
+                      </p>
+                    </div>
                   </div>
-                </div>
-                <div className="flex items-start gap-6">
-                  <div className="size-12 bg-primary/10 flex items-center justify-center shrink-0">
-                    <span className="text-primary font-bold text-xl">02</span>
-                  </div>
-                  <div>
-                    <h3 className="text-xl font-semibold text-white mb-2">
-                      Ship fast, iterate faster
-                    </h3>
-                    <p className="text-neutral-400">
-                      We believe in rapid iteration with community feedback.
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-start gap-6">
-                  <div className="size-12 bg-primary/10 flex items-center justify-center shrink-0">
-                    <span className="text-primary font-bold text-xl">03</span>
-                  </div>
-                  <div>
-                    <h3 className="text-xl font-semibold text-white mb-2">
-                      Community-driven development
-                    </h3>
-                    <p className="text-neutral-400">
-                      PRs welcome. Issues welcome. Ideas welcome.
-                    </p>
+                  <div className="flex items-start gap-4 sm:gap-6">
+                    <div className="size-10 sm:size-12 bg-primary/10 flex items-center justify-center shrink-0">
+                      <span className="text-primary font-bold text-lg sm:text-xl">03</span>
+                    </div>
+                    <div>
+                      <h3 className="text-lg sm:text-xl font-semibold text-white mb-1 sm:mb-2">
+                        Community-driven development
+                      </h3>
+                      <p className="text-sm sm:text-base text-neutral-400">
+                        PRs welcome. Issues welcome. Ideas welcome.
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -415,51 +419,53 @@ export function PresentationDeck({
         {/* Slide 5: Where we are */}
         {currentSlide === 4 && (
           <div className={slideClasses}>
-            <div className="max-w-6xl w-full">
-              <p className="text-primary text-lg font-medium mb-4 text-center">
-                Where we are
-              </p>
-              <h2 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-4 text-center">
-                Born in <span className="text-primary">Peru</span>, now global
-              </h2>
-              <p className="text-lg md:text-xl text-neutral-400 mb-8 text-center">
-                A distributed community across LATAM & Europe
-              </p>
+            <div className={slideInner}>
+              <div className="max-w-6xl w-full">
+                <p className="text-primary text-base sm:text-lg font-medium mb-3 sm:mb-4 text-center">
+                  Where we are
+                </p>
+                <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-white leading-tight mb-3 sm:mb-4 text-center">
+                  Born in <span className="text-primary">Peru</span>, now global
+                </h2>
+                <p className="text-base sm:text-lg md:text-xl text-neutral-400 mb-6 sm:mb-8 text-center">
+                  A distributed community across LATAM & Europe
+                </p>
 
-              {/* Real Map visualization */}
-              <div className="relative w-full max-w-4xl mx-auto aspect-[2/1] bg-neutral-950/50 border border-neutral-800 overflow-hidden rounded-lg">
-                <WorldMap
-                  locations={[
-                    { city: "Lima", country: "Peru", countryCode: "604", lat: -12.0464, lng: -77.0428, isHQ: true },
-                    { city: "Arequipa", country: "Peru", countryCode: "604", lat: -16.409, lng: -71.537 },
-                    { city: "Bogotá", country: "Colombia", countryCode: "170", lat: 4.711, lng: -74.0721 },
-                    { city: "Medellín", country: "Colombia", countryCode: "170", lat: 6.2442, lng: -75.5812 },
-                    { city: "São Paulo", country: "Brazil", countryCode: "076", lat: -23.5505, lng: -46.6333 },
-                    { city: "Madrid", country: "Spain", countryCode: "724", lat: 40.4168, lng: -3.7038 },
-                  ]}
-                />
-                {/* Gradient overlay */}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent pointer-events-none" />
-              </div>
+                {/* Real Map visualization */}
+                <div className="relative w-full max-w-4xl mx-auto aspect-[2/1] bg-neutral-950/50 border border-neutral-800 overflow-hidden rounded-lg">
+                  <WorldMap
+                    locations={[
+                      { city: "Lima", country: "Peru", countryCode: "604", lat: -12.0464, lng: -77.0428, isHQ: true },
+                      { city: "Arequipa", country: "Peru", countryCode: "604", lat: -16.409, lng: -71.537 },
+                      { city: "Bogotá", country: "Colombia", countryCode: "170", lat: 4.711, lng: -74.0721 },
+                      { city: "Medellín", country: "Colombia", countryCode: "170", lat: 6.2442, lng: -75.5812 },
+                      { city: "São Paulo", country: "Brazil", countryCode: "076", lat: -23.5505, lng: -46.6333 },
+                      { city: "Madrid", country: "Spain", countryCode: "724", lat: 40.4168, lng: -3.7038 },
+                    ]}
+                  />
+                  {/* Gradient overlay */}
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent pointer-events-none" />
+                </div>
 
-              {/* City list */}
-              <div className="flex flex-wrap justify-center gap-4 md:gap-8 mt-8">
-                {[
-                  { city: "Lima", country: "Peru", flag: "🇵🇪", isHQ: true },
-                  { city: "Arequipa", country: "Peru", flag: "🇵🇪" },
-                  { city: "Bogotá", country: "Colombia", flag: "🇨🇴" },
-                  { city: "Medellín", country: "Colombia", flag: "🇨🇴" },
-                  { city: "São Paulo", country: "Brazil", flag: "🇧🇷" },
-                  { city: "Madrid", country: "Spain", flag: "🇪🇸" },
-                ].map((loc) => (
-                  <div key={loc.city} className={`flex items-center gap-2 ${loc.isHQ ? 'text-primary' : 'text-neutral-400'}`}>
-                    <span className="text-lg">{loc.flag}</span>
-                    <span className={`text-sm ${loc.isHQ ? 'font-semibold' : ''}`}>
-                      {loc.city}
-                      {loc.isHQ && <span className="text-xs ml-1 opacity-70">(HQ)</span>}
-                    </span>
-                  </div>
-                ))}
+                {/* City list */}
+                <div className="flex flex-wrap justify-center gap-x-3 gap-y-2 sm:gap-4 md:gap-8 mt-6 sm:mt-8">
+                  {[
+                    { city: "Lima", country: "Peru", flag: "🇵🇪", isHQ: true },
+                    { city: "Arequipa", country: "Peru", flag: "🇵🇪" },
+                    { city: "Bogotá", country: "Colombia", flag: "🇨🇴" },
+                    { city: "Medellín", country: "Colombia", flag: "🇨🇴" },
+                    { city: "São Paulo", country: "Brazil", flag: "🇧🇷" },
+                    { city: "Madrid", country: "Spain", flag: "🇪🇸" },
+                  ].map((loc) => (
+                    <div key={loc.city} className={`flex items-center gap-1.5 sm:gap-2 ${loc.isHQ ? 'text-primary' : 'text-neutral-400'}`}>
+                      <span className="text-base sm:text-lg">{loc.flag}</span>
+                      <span className={`text-xs sm:text-sm ${loc.isHQ ? 'font-semibold' : ''}`}>
+                        {loc.city}
+                        {loc.isHQ && <span className="text-[10px] sm:text-xs ml-1 opacity-70">(HQ)</span>}
+                      </span>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
@@ -468,30 +474,32 @@ export function PresentationDeck({
         {/* Slide 6: Projects */}
         {currentSlide === 5 && (
           <div className={slideClasses}>
-            <div className="max-w-5xl w-full">
-              <p className="text-primary text-lg font-medium mb-4 text-center">
-                What we've built
-              </p>
-              <h2 className="text-4xl md:text-5xl font-bold text-white text-center mb-12">
-                Our Projects
-              </h2>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                {projects.slice(0, 4).map((project) => (
-                  <div
-                    key={project.name}
-                    className="p-6 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors"
-                  >
-                    <span className="px-2 py-1 text-xs font-medium bg-primary/20 text-primary mb-4 inline-block">
-                      {project.stars}
-                    </span>
-                    <h3 className="text-xl md:text-2xl font-bold text-white mb-2">
-                      {project.name}
-                    </h3>
-                    <p className="text-sm text-neutral-400">
-                      {project.description}
-                    </p>
-                  </div>
-                ))}
+            <div className={slideInner}>
+              <div className="max-w-5xl w-full">
+                <p className="text-primary text-base sm:text-lg font-medium mb-3 sm:mb-4 text-center">
+                  What we've built
+                </p>
+                <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-white text-center mb-8 sm:mb-12">
+                  Our Projects
+                </h2>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4">
+                  {projects.slice(0, 4).map((project) => (
+                    <div
+                      key={project.name}
+                      className="p-4 sm:p-6 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors"
+                    >
+                      <span className="px-2 py-0.5 sm:py-1 text-[10px] sm:text-xs font-medium bg-primary/20 text-primary mb-3 sm:mb-4 inline-block">
+                        {project.stars}
+                      </span>
+                      <h3 className="text-lg sm:text-xl md:text-2xl font-bold text-white mb-1 sm:mb-2">
+                        {project.name}
+                      </h3>
+                      <p className="text-xs sm:text-sm text-neutral-400">
+                        {project.description}
+                      </p>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
@@ -500,31 +508,33 @@ export function PresentationDeck({
         {/* Slide 7: Team */}
         {currentSlide === 6 && (
           <div className={slideClasses}>
-            <div className="max-w-5xl w-full">
-              <p className="text-primary text-lg font-medium mb-4 text-center">
-                The humans behind the code
-              </p>
-              <h2 className="text-4xl md:text-5xl font-bold text-white text-center mb-12">
-                Meet Our Team
-              </h2>
-              <div className="grid grid-cols-3 md:grid-cols-5 gap-4 md:gap-6">
-                {teamMembers.slice(0, 10).map((member) => (
-                  <div key={member.username} className="text-center group">
-                    <div className="aspect-square overflow-hidden border border-neutral-800 mb-3">
-                      <img
-                        src={member.photoUrl}
-                        alt={member.name}
-                        className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500"
-                      />
+            <div className={slideInner}>
+              <div className="max-w-5xl w-full">
+                <p className="text-primary text-base sm:text-lg font-medium mb-3 sm:mb-4 text-center">
+                  The humans behind the code
+                </p>
+                <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-white text-center mb-8 sm:mb-12">
+                  Meet Our Team
+                </h2>
+                <div className="grid grid-cols-3 md:grid-cols-5 gap-3 sm:gap-4 md:gap-6">
+                  {teamMembers.slice(0, 10).map((member) => (
+                    <div key={member.username} className="text-center group">
+                      <div className="aspect-square overflow-hidden border border-neutral-800 mb-2 sm:mb-3">
+                        <img
+                          src={member.photoUrl}
+                          alt={member.name}
+                          className="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-500"
+                        />
+                      </div>
+                      <p className="font-semibold text-white text-xs sm:text-sm md:text-base truncate">
+                        {member.name.split(" ")[0]}
+                      </p>
+                      <p className="text-[10px] sm:text-xs text-neutral-500 truncate">
+                        {member.position}
+                      </p>
                     </div>
-                    <p className="font-semibold text-white text-sm md:text-base truncate">
-                      {member.name.split(" ")[0]}
-                    </p>
-                    <p className="text-xs text-neutral-500 truncate">
-                      {member.position}
-                    </p>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
             </div>
           </div>
@@ -533,48 +543,50 @@ export function PresentationDeck({
         {/* Slide 8: By the numbers */}
         {currentSlide === 7 && (
           <div className={slideClasses}>
-            <div className="max-w-6xl w-full">
-              <p className="text-primary text-lg font-medium mb-4 text-center">
-                By the numbers
-              </p>
-              <h2 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white text-center mb-4 leading-tight">
-                A community that <span className="text-primary">ships</span>
-              </h2>
-              <p className="text-lg md:text-xl text-neutral-400 mb-12 text-center">
-                Three years of building in public across LATAM
-              </p>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6">
-                <div className="p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
-                  <p className="text-5xl md:text-6xl font-black text-primary mb-3">
-                    700+
-                  </p>
-                  <p className="text-sm md:text-base text-neutral-400">
-                    Community members
-                  </p>
-                </div>
-                <div className="p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
-                  <p className="text-5xl md:text-6xl font-black text-primary mb-3">
-                    5+
-                  </p>
-                  <p className="text-sm md:text-base text-neutral-400">
-                    Hackathons organized
-                  </p>
-                </div>
-                <div className="p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
-                  <p className="text-5xl md:text-6xl font-black text-primary mb-3">
-                    10+
-                  </p>
-                  <p className="text-sm md:text-base text-neutral-400">
-                    Online events
-                  </p>
-                </div>
-                <div className="p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
-                  <p className="text-5xl md:text-6xl font-black text-primary mb-3">
-                    {pastEventsCount}+
-                  </p>
-                  <p className="text-sm md:text-base text-neutral-400">
-                    Past events hosted
-                  </p>
+            <div className={slideInner}>
+              <div className="max-w-6xl w-full">
+                <p className="text-primary text-base sm:text-lg font-medium mb-3 sm:mb-4 text-center">
+                  By the numbers
+                </p>
+                <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-white text-center mb-3 sm:mb-4 leading-tight">
+                  A community that <span className="text-primary">ships</span>
+                </h2>
+                <p className="text-base sm:text-lg md:text-xl text-neutral-400 mb-8 sm:mb-12 text-center">
+                  Three years of building in public across LATAM
+                </p>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 md:gap-6">
+                  <div className="p-4 sm:p-6 md:p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
+                    <p className="text-4xl sm:text-5xl md:text-6xl font-black text-primary mb-2 sm:mb-3">
+                      700+
+                    </p>
+                    <p className="text-xs sm:text-sm md:text-base text-neutral-400">
+                      Community members
+                    </p>
+                  </div>
+                  <div className="p-4 sm:p-6 md:p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
+                    <p className="text-4xl sm:text-5xl md:text-6xl font-black text-primary mb-2 sm:mb-3">
+                      5+
+                    </p>
+                    <p className="text-xs sm:text-sm md:text-base text-neutral-400">
+                      Hackathons organized
+                    </p>
+                  </div>
+                  <div className="p-4 sm:p-6 md:p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
+                    <p className="text-4xl sm:text-5xl md:text-6xl font-black text-primary mb-2 sm:mb-3">
+                      10+
+                    </p>
+                    <p className="text-xs sm:text-sm md:text-base text-neutral-400">
+                      Online events
+                    </p>
+                  </div>
+                  <div className="p-4 sm:p-6 md:p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
+                    <p className="text-4xl sm:text-5xl md:text-6xl font-black text-primary mb-2 sm:mb-3">
+                      {pastEventsCount}+
+                    </p>
+                    <p className="text-xs sm:text-sm md:text-base text-neutral-400">
+                      Past events hosted
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -584,77 +596,79 @@ export function PresentationDeck({
         {/* Slide 9: Connect */}
         {currentSlide === 8 && (
           <div className={slideClasses}>
-            <div className="max-w-4xl text-center">
-              <h2 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-8">
-                Let's <span className="text-primary">connect</span>
-              </h2>
-              <p className="text-xl md:text-2xl text-neutral-400 mb-12">
-                Join our community and build with us
-              </p>
-              <div className="flex flex-wrap justify-center gap-4">
-                <a
-                  href="https://github.com/crafter-station"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-3 px-6 py-4 bg-white text-black font-semibold hover:bg-primary transition-colors"
-                  onClick={() => track('social_click', { platform: 'github', location: 'deck_connect' })}
-                >
-                  <svg className="size-6" fill="currentColor" viewBox="0 0 24 24">
-                    <path
-                      fillRule="evenodd"
-                      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  GitHub
-                </a>
-                <a
-                  href="https://discord.gg/QvsS4jNpKa"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-3 px-6 py-4 bg-[#5865F2] text-white font-semibold hover:bg-[#4752C4] transition-colors"
-                  onClick={() => track('social_click', { platform: 'discord', location: 'deck_connect' })}
-                >
-                  <svg className="size-6" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994.021-.041.001-.09-.041-.106a13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.118.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-                  </svg>
-                  Discord
-                </a>
-                <a
-                  href="https://x.com/CrafterStation"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-3 px-6 py-4 border border-neutral-700 text-white font-semibold hover:border-primary hover:text-primary transition-colors"
-                  onClick={() => track('social_click', { platform: 'x', location: 'deck_connect' })}
-                >
-                  <svg className="size-6" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                  </svg>
-                  X / Twitter
-                </a>
-              </div>
-              <div className="mt-12 pt-8 border-t border-neutral-800">
-                <a
-                  href="https://railly.dev/meet"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                  onClick={() => track('cta_click', { label: 'book_a_call', location: 'deck_connect' })}
-                >
-                  Book a call with us →
-                </a>
+            <div className={slideInner}>
+              <div className="max-w-4xl w-full text-center">
+                <h2 className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-6 sm:mb-8">
+                  Let's <span className="text-primary">connect</span>
+                </h2>
+                <p className="text-base sm:text-xl md:text-2xl text-neutral-400 mb-8 sm:mb-12">
+                  Join our community and build with us
+                </p>
+                <div className="flex flex-col sm:flex-row sm:flex-wrap justify-center gap-3 sm:gap-4">
+                  <a
+                    href="https://github.com/crafter-station"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center gap-3 px-5 py-3 sm:px-6 sm:py-4 bg-white text-black text-sm sm:text-base font-semibold hover:bg-primary transition-colors"
+                    onClick={() => track('social_click', { platform: 'github', location: 'deck_connect' })}
+                  >
+                    <svg className="size-5 sm:size-6" fill="currentColor" viewBox="0 0 24 24">
+                      <path
+                        fillRule="evenodd"
+                        d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                    GitHub
+                  </a>
+                  <a
+                    href="https://discord.gg/QvsS4jNpKa"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center gap-3 px-5 py-3 sm:px-6 sm:py-4 bg-[#5865F2] text-white text-sm sm:text-base font-semibold hover:bg-[#4752C4] transition-colors"
+                    onClick={() => track('social_click', { platform: 'discord', location: 'deck_connect' })}
+                  >
+                    <svg className="size-5 sm:size-6" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994.021-.041.001-.09-.041-.106a13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.118.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+                    </svg>
+                    Discord
+                  </a>
+                  <a
+                    href="https://x.com/CrafterStation"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center gap-3 px-5 py-3 sm:px-6 sm:py-4 border border-neutral-700 text-white text-sm sm:text-base font-semibold hover:border-primary hover:text-primary transition-colors"
+                    onClick={() => track('social_click', { platform: 'x', location: 'deck_connect' })}
+                  >
+                    <svg className="size-5 sm:size-6" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                    </svg>
+                    X / Twitter
+                  </a>
+                </div>
+                <div className="mt-8 sm:mt-12 pt-6 sm:pt-8 border-t border-neutral-800">
+                  <a
+                    href="https://railly.dev/meet"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm sm:text-base text-primary hover:underline"
+                    onClick={() => track('cta_click', { label: 'book_a_call', location: 'deck_connect' })}
+                  >
+                    Book a call with us →
+                  </a>
+                </div>
               </div>
             </div>
           </div>
         )}
       </div>
 
-      {/* Navigation arrows */}
+      {/* Navigation arrows - desktop only (mobile uses swipe + dots) */}
       <button
         onClick={prevSlide}
         disabled={currentSlide === 0}
         className={`
-          absolute left-4 md:left-8 top-1/2 -translate-y-1/2 p-3
+          hidden md:block absolute left-8 top-1/2 -translate-y-1/2 p-3
           transition-all z-50
           ${currentSlide === 0 ? "opacity-20 cursor-not-allowed" : "opacity-100 hover:bg-neutral-900 hover:text-primary"}
         `}
@@ -678,7 +692,7 @@ export function PresentationDeck({
         onClick={nextSlide}
         disabled={currentSlide === slides.length - 1}
         className={`
-          absolute right-4 md:right-8 top-1/2 -translate-y-1/2 p-3
+          hidden md:block absolute right-8 top-1/2 -translate-y-1/2 p-3
           transition-all z-50
           ${currentSlide === slides.length - 1 ? "opacity-20 cursor-not-allowed" : "opacity-100 hover:bg-neutral-900 hover:text-primary"}
         `}

--- a/src/components/PresentationDeck.tsx
+++ b/src/components/PresentationDeck.tsx
@@ -20,6 +20,7 @@ interface Project {
 interface PresentationDeckProps {
   teamMembers: TeamMember[];
   projects: Project[];
+  pastEventsCount: number;
 }
 
 const slides = [
@@ -30,12 +31,14 @@ const slides = [
   { id: "where", label: "Where" },
   { id: "projects", label: "Projects" },
   { id: "team", label: "Team" },
+  { id: "numbers", label: "Numbers" },
   { id: "connect", label: "Connect" },
 ];
 
 export function PresentationDeck({
   teamMembers,
   projects,
+  pastEventsCount,
 }: PresentationDeckProps) {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -527,8 +530,59 @@ export function PresentationDeck({
           </div>
         )}
 
-        {/* Slide 8: Connect */}
+        {/* Slide 8: By the numbers */}
         {currentSlide === 7 && (
+          <div className={slideClasses}>
+            <div className="max-w-6xl w-full">
+              <p className="text-primary text-lg font-medium mb-4 text-center">
+                By the numbers
+              </p>
+              <h2 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white text-center mb-4 leading-tight">
+                A community that <span className="text-primary">ships</span>
+              </h2>
+              <p className="text-lg md:text-xl text-neutral-400 mb-12 text-center">
+                Three years of building in public across LATAM
+              </p>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6">
+                <div className="p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
+                  <p className="text-5xl md:text-6xl font-black text-primary mb-3">
+                    700+
+                  </p>
+                  <p className="text-sm md:text-base text-neutral-400">
+                    Community members
+                  </p>
+                </div>
+                <div className="p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
+                  <p className="text-5xl md:text-6xl font-black text-primary mb-3">
+                    5+
+                  </p>
+                  <p className="text-sm md:text-base text-neutral-400">
+                    Hackathons organized
+                  </p>
+                </div>
+                <div className="p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
+                  <p className="text-5xl md:text-6xl font-black text-primary mb-3">
+                    10+
+                  </p>
+                  <p className="text-sm md:text-base text-neutral-400">
+                    Online events
+                  </p>
+                </div>
+                <div className="p-8 bg-neutral-950 border border-neutral-800 hover:border-primary/50 transition-colors">
+                  <p className="text-5xl md:text-6xl font-black text-primary mb-3">
+                    {pastEventsCount}+
+                  </p>
+                  <p className="text-sm md:text-base text-neutral-400">
+                    Past events hosted
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Slide 9: Connect */}
+        {currentSlide === 8 && (
           <div className={slideClasses}>
             <div className="max-w-4xl text-center">
               <h2 className="text-4xl md:text-6xl lg:text-7xl font-bold text-white leading-tight mb-8">

--- a/src/pages/deck.astro
+++ b/src/pages/deck.astro
@@ -4,6 +4,10 @@ export const prerender = true;
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { PresentationDeck } from "@/components/PresentationDeck";
 import { teamMembers } from "@/lib/constants/team";
+import { fetchCrafterStationEvents } from "@/lib/luma";
+
+const { past } = await fetchCrafterStationEvents();
+const pastEventsCount = past.length > 0 ? past.length : 50;
 
 const projects = [
     {
@@ -48,5 +52,10 @@ const teamData = teamMembers.map((member) => ({
     title="Deck | Crafter Station"
     description="Learn about Crafter Station - an open source community building developer tools in public from Peru."
 >
-    <PresentationDeck client:load teamMembers={teamData} projects={projects} />
+    <PresentationDeck
+        client:load
+        teamMembers={teamData}
+        projects={projects}
+        pastEventsCount={pastEventsCount}
+    />
 </BaseLayout>


### PR DESCRIPTION
## Summary

Three related changes on this branch:

1. **`/deck` — new "By the numbers" slide** — inserted between Team and Connect. Highlights **700+ community members**, **5+ hackathons organized**, **10+ online events**, and a live count of **past events hosted** (pulled from `fetchCrafterStationEvents()` in `src/lib/luma.ts`, fallback to `50` when `LUMA_API_KEY` is missing).
2. **`/deck` — mobile responsive overhaul** across all 9 slides:
   - Slides now scroll vertically when content overflows the viewport (`overflow-y-auto` outer + `min-h-full flex` inner wrapper).
   - Tighter mobile padding and chrome positions (counter, back, dots moved to `top-3` / `bottom-4` on mobile).
   - Aggressive typography scaling per slide (`text-3xl sm:text-4xl md:text-6xl …`).
   - Swipe hint removed (redundant with dots + actual gesture).
   - Nav arrows hidden on mobile; swipe + dots remain.
   - Connect slide buttons stack vertically on small screens.

## Files

- `src/pages/deck.astro` — fetches Luma events and passes `pastEventsCount`
- `src/components/PresentationDeck.tsx` — new Numbers slide + full mobile responsive pass

## Test plan

- [ ] Open `/deck` on desktop — counter, back link, nav arrows, dots, keyboard hint all visible. All 9 slides render. Keyboard (← →, 1–9, Home/End) and click navigation work.
- [ ] Open `/deck` on mobile (or DevTools 360–414px) — counter and back land in top-left/top-right corners without overlapping content. Dots are at bottom-center, compact. Swipe gesture navigates. Nav arrows hidden.
- [ ] Verify each slide on mobile has no content cut off — taller slides (Values, How, Team, Numbers) scroll inside the slide when needed.
- [ ] Numbers slide displays 700+ / 5+ / 10+ / `pastEventsCount`+ tiles; with `LUMA_API_KEY` set, the 4th tile reflects live past events.
- [ ] Connect slide: GitHub / Discord / X buttons render and stack vertically on mobile.
- [ ] Build passes (`bun run build`).
